### PR TITLE
Change <tenant> to <clientCode>

### DIFF
--- a/src/pages/before-administer/models-api.md
+++ b/src/pages/before-administer/models-api.md
@@ -50,7 +50,7 @@ Before blocklisting a feature, view the list of features that are currently bein
 #### Request
 
 ```json
-GET https://mc.adobe.io/<tenant>/target/models/features/<campaignId>
+GET https://mc.adobe.io/<clientCode>/target/models/features/<campaignId>
 ```
 
 #### Response
@@ -80,7 +80,7 @@ GET https://mc.adobe.io/<tenant>/target/models/features/<campaignId>
         }
     ],
     "reportParameters": {
-        "clientCode": <tenant>,
+        "clientCode": <clientCode>,
         "campaignId": <campaignId>
     }
 }
@@ -122,7 +122,7 @@ Note that `/blockList/` is case sensitive in the request.
 #### Request
 
 ```json
-GET https://mc.adobe.io/<tenant>/target/models/features/blockList/<campaignId>
+GET https://mc.adobe.io/<clientCode>/target/models/features/blockList/<campaignId>
 ```
 
 #### Response
@@ -171,7 +171,7 @@ Note that `blockedFeatureSources` indicates where a feature came from. For the p
 #### Request
 
 ```json
-PUT https://mc.adobe.io/<tenant>/target/models/features/blockList/<campaignId>
+PUT https://mc.adobe.io/<clientCode>/target/models/features/blockList/<campaignId>
 
 {
     "blockedFeatureSources": ["AAM"],
@@ -211,7 +211,7 @@ To unblock all blocklisted features, clear the values from `blockedFeatureSource
 #### Request
 
 ```json
-PUT https://mc.adobe.io/<tenant>/target/models/features/blockList/<campaignId>
+PUT https://mc.adobe.io/<clientCode>/target/models/features/blockList/<campaignId>
 
 {
     "blockedFeatureSources": [],
@@ -252,7 +252,7 @@ The examples above were all in the context of a single activity. You may also bl
 #### Request
 
 ```json
-PUT https://mc.adobe.io/<tenant>/target/models/features/blockList/global
+PUT https://mc.adobe.io/<clientCode>/target/models/features/blockList/global
 
 {
     "blockedFeatureSources": ["AAM", "PRO", "ENV"],


### PR DESCRIPTION
In my testing, these methods seem to use clientCode in place of tenantId in the request URLs. The current-customer facing documentation says to use tenantId, which could cause confusion for customers since tentandId and clientCode do not always match on customer accounts.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
